### PR TITLE
Do not use travis.cfg.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 install:
-  - python bootstrap-buildout.py -c travis.cfg
-  - bin/buildout -Nc travis.cfg
+  - python bootstrap-buildout.py
+  - bin/buildout
 script:
   - bin/code-analysis
   - bin/test --all


### PR DESCRIPTION
@andreasma the travis job works now. There are a few code violations that prevent the build from passing:

https://travis-ci.org/tdf/extensions.libreoffice.org/builds/177314924

Once you merged this pull request you can either fix those violations or we disable the code checks and just run the tests on travis.